### PR TITLE
Prevent 'undefined' from being appended to API resource URL when using custom Axios instance

### DIFF
--- a/dist/Resource.d.ts
+++ b/dist/Resource.d.ts
@@ -34,6 +34,7 @@ export declare class Resource {
     private queryParams;
     constructor(options: ResourceOptions);
     add(options: ResourceActionOptions): Resource;
+    private readonly normalizedBaseURL;
     private getDispatchString(action);
     private getCommitString(action);
 }

--- a/dist/Resource.js
+++ b/dist/Resource.js
@@ -23,10 +23,10 @@ var Resource = /** @class */ (function () {
         var completePathFn;
         if (typeof options.path === "function") {
             var pathFn_1 = options.path;
-            completePathFn = function (params) { return _this.baseURL + pathFn_1(params); };
+            completePathFn = function (params) { return _this.normalizedBaseURL + pathFn_1(params); };
         }
         else {
-            completePathFn = function () { return _this.baseURL + options.path; };
+            completePathFn = function () { return _this.normalizedBaseURL + options.path; };
         }
         this.actions[options.action] = {
             requestFn: function (params, data) {
@@ -62,6 +62,13 @@ var Resource = /** @class */ (function () {
         };
         return this;
     };
+    Object.defineProperty(Resource.prototype, "normalizedBaseURL", {
+        get: function () {
+            return this.baseURL || this.axios.defaults.baseURL || "";
+        },
+        enumerable: true,
+        configurable: true
+    });
     Resource.prototype.getDispatchString = function (action) {
         return action;
     };

--- a/dist/Store.js
+++ b/dist/Store.js
@@ -155,7 +155,7 @@ var StoreCreator = /** @class */ (function () {
                 if (actionParams === void 0) { actionParams = { params: {}, data: {} }; }
                 return __awaiter(_this, void 0, void 0, function () {
                     var _this = this;
-                    return __generator(this, function (_a) {
+                    return __generator(this, function (_b) {
                         if (!actionParams.params)
                             actionParams.params = {};
                         if (!actionParams.data)

--- a/src/Resource.ts
+++ b/src/Resource.ts
@@ -60,10 +60,10 @@ export class Resource {
     let completePathFn: Function
     if (typeof options.path === "function") {
       const pathFn: Function = options.path
-      completePathFn = (params: Object) => this.baseURL + pathFn(params)
+      completePathFn = (params: Object) => this.normalizedBaseURL + pathFn(params)
     }
     else {
-      completePathFn = () => this.baseURL + options.path
+      completePathFn = () => this.normalizedBaseURL + options.path
     }
 
     this.actions[options.action] = {
@@ -99,6 +99,10 @@ export class Resource {
     }
 
     return this
+  }
+
+  private get normalizedBaseURL(): string {
+    return this.baseURL || (this.axios as any).defaults.baseURL || ""
   }
 
   private getDispatchString(action: string): string {


### PR DESCRIPTION
**Problem**

When using a custom `axios` instance it's possible for the final resource URL to include an [unwanted `undefined` string literal](https://stackoverflow.com/q/20572016), like so:

Unwanted result: `http://localhost:8080/undefined/v1/user`
Desired result: `http://localhost:8080/v1/user`

This only happens when using a custom `axios` instance because, in this case, the user typically avoids setting the core `baseURL` property and instead only sets the property in `axios`. Ideally users should only set one or the other.

**Solution**

This proposed change corrects the problem by introducing the `normalizedBaseURL` getter.

This method explicitly checks for and utilizes the `baseURL` value defined in `axios`.