### PR TITLE
Fix typo error on Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,8 +447,8 @@ export default {
   // make states available
   computed: mapState({
     posts: state => state.posts.posts,
-    pending: state => state.posts.pending,
-    error: state => state.posts.error
+    pending: state => state.pending,
+    error: state => state.error
   }),
   methods: {
     ...mapActions([


### PR DESCRIPTION
Hello

In documentation you are using `state.pending.<propertyName>` (`true` when loading, otherwise `false`)
But un component you are using `state.<propertyName>.pending.<propertyName>`