### PR TITLE
Allow all HTTP request methods to set a payload.

### DIFF
--- a/src/Resource.ts
+++ b/src/Resource.ts
@@ -100,17 +100,15 @@ export class Resource {
           }
         }
 
-        // This is assignment is made to respect the priority of the base URL
+        // This is assignment is made to respect the priority of the base URL, url, method and data.
         // It is as following: baseURL > axios instance base URL > request config base URL
-        const requestConfigWithProperBaseURL = Object.assign({
-          baseURL: this.normalizedBaseURL
+        const fullRequestConfig = Object.assign({
+          method: options.method,
+          url: urlFn(params),
+          baseURL: this.normalizedBaseURL,
+          data: data
         }, requestConfig)
-
-        if (["post", "put", "patch"].indexOf(options.method) > -1) {
-          return this.axios[options.method](urlFn(params), data, requestConfigWithProperBaseURL)
-        } else {
-          return this.axios[options.method](urlFn(params), requestConfigWithProperBaseURL)
-        }
+        return this.axios.request(fullRequestConfig)
       },
       property: options.property,
       beforeRequest: options.beforeRequest,


### PR DESCRIPTION
The HTTP standard allows for payloads in non POST/PUT/PATH requests, and so does Axios.
Axios does require it to be passed via the config instead of as the second parameter, see axios/axios#897 and [the relevant docs](https://github.com/axios/axios#request-method-aliases).
To make things simpler I put everything into a config object and pass that to the request call instead of using the method aliases.

This was written in the GitHub editor, and it's my frist time writing typescript, so please advise if I'm doing something wrong.

This change will allow me to fully use this library. For now I have hack around this with some ugly direct state manipulation.